### PR TITLE
Embed Images Inside HTML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bin/unoconv
+Pipfile*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM alpine:edge
-RUN apk add --no-cache bash libreoffice python3
+RUN apk add --no-cache bash libreoffice python3 libmagic \
+    && pip3 install beautifulsoup4 python-magic
 ADD bin /bin
 ENTRYPOINT ["/bin/folder2html"]

--- a/bin/folder2html
+++ b/bin/folder2html
@@ -18,6 +18,8 @@ for file in *; do mv "$file" `echo $file | tr ' ' '_'` ; done
 for file in *.*; do
     echo "Converting $file to html"
     /usr/bin/python3 /bin/unoconv -f html $file
+    echo "Embedding images into html"
+    /usr/bin/python3 /bin/inline-image $file
 done
 
 echo "Done!"

--- a/bin/folder2html
+++ b/bin/folder2html
@@ -16,7 +16,11 @@ for file in *; do mv "$file" `echo $file | tr ' ' '_'` ; done
 
 # Convert each file to HTML, requires pyunolib (provided by libreoffice)
 for file in *.*; do
+    # Ignore any HTML files that may exist
+    [[ $file == *.html ]] && continue
+
     echo "Converting $file to html"
+    # This will overwrite any existing html files
     /usr/bin/python3 /bin/unoconv -f html $file
     echo "Embedding images into html"
     /usr/bin/python3 /bin/inline-image $file

--- a/bin/inline-image
+++ b/bin/inline-image
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+# Part of Alpine-Unoconv
+# Copyright 2019-2020 David Todd <dtodd@oceantech.com>
+# License: MIT - Refer to license.md for more information
+
+# This is a small script that will parse an html file for
+# <img> tags, convert the image to base64, and embed it
+# in the html file
+
+import os
+import sys
+import base64
+import magic
+from bs4 import BeautifulSoup
+
+class ImageUtility():
+    """
+        Contains methods for determining a mimetype
+        and converting an image to base64
+    """
+
+    def __init__(self, image_path):
+        """
+            Contains information that is required
+            to run the included methods
+        """
+
+        self.image_path = image_path
+
+    def get_mimetype(self):
+        """
+            Returns the mimetype of the provided `self.file_path`
+        """
+
+        return magic.from_file(self.image_path, mime=True)
+
+    def convert_to_base64(self):
+        """
+            Returns the base64 representation of the provided `self.image_path`
+        """
+        image_contents = False
+        print(" > Converting %s to base64 for embedding" % (self.image_path))
+        with open(self.image_path, 'rb') as the_image:
+            image_contents = base64.b64encode(the_image.read())
+        the_image.close()
+        print(" > Deleting %s" % (self.image_path))
+        os.remove(self.image_path)
+        return image_contents.decode('utf-8')
+
+class HTMLUtility():
+    """
+        Contains methods for making changes to a provided html file
+    """
+
+    def __init__(self, html_path):
+        """
+            Contains information that is required
+            to run the included methods
+        """
+
+        # When used in conjunction with alpine-unoconv, the file
+        # that gets set as an argument to this script is NOT
+        # html. However, the real html file has the same filename
+        # with `.html` as the extension. This is a hack, but it works
+        real_html_path = os.path.splitext(html_path)[0] + '.html'
+        self.html_path = real_html_path
+
+    def read_html(self):
+        """
+            Reads the entire HTML file into memory so
+            that we can replace it later
+        """
+        html_content = False
+        print(" > Reading %s" % (self.html_path))
+        # LibreOffice exports HTML files encoded as `ISO-8859-1` (`latin-1`)
+        # Python3 expects the encoding to be UTF-8 by default, which may have
+        # incompatible bytes
+        with open(self.html_path, 'r', encoding='iso-8859-1') as html_file:
+            html_content = html_file.read()
+        html_file.close()
+        return html_content
+
+    def write_html(self, content):
+        """
+            Overrites the `self.html_path` with `content`
+        """
+        print(" > Writing %s" % (self.html_path))
+        with open(self.html_path, 'w') as html_file:
+            html_file.write(content)
+        html_file.close()
+
+    def replace_image_with_inline(self):
+        """
+            Replaces all instances of <img> that
+            link to an actual file, with one that
+            contains the base64 representation of
+            the image
+        """
+        # Determine the path where the files are located
+        base_path = os.path.split(self.html_path.rstrip(os.path.sep))[0]
+
+        soup = BeautifulSoup(self.read_html(), 'html.parser')
+
+        print(" > Parsing %s for <img> tags" % (self.html_path))
+        for dest_image in soup.find_all('img'):
+            # Determine where the image is, relative to the html file
+            img_path = os.path.join(base_path, dest_image.attrs['src'])
+            img_util = ImageUtility(img_path)
+
+            # Get the mimetype and base64 representation
+            img_mime = img_util.get_mimetype()
+            img_b64 = img_util.convert_to_base64()
+
+            # Change the image `src` link
+            print(" > Embedding %s into %s" % (img_path, self.html_path))
+            img_src = "data:%s;base64,%s" % (img_mime, img_b64)
+            dest_image.attrs['src'] = img_src
+
+        self.write_html(str(soup))
+
+if __name__ == '__main__':
+    print("> Preparing to embed")
+    HTMLUtility(sys.argv[1]).replace_image_with_inline()
+    print("> All Images embedded")

--- a/bin/inline-image
+++ b/bin/inline-image
@@ -3,8 +3,8 @@
 # Copyright 2019-2020 David Todd <dtodd@oceantech.com>
 # License: MIT - Refer to license.md for more information
 
-# This is a small script that will parse an html file for
-# <img> tags, convert the image to base64, and embed it
+# This script will parse an html file for <img> tags,
+# convert the image to base64, and embed it
 # in the html file
 
 import os
@@ -13,7 +13,7 @@ import base64
 import magic
 from bs4 import BeautifulSoup
 
-class ImageUtility():
+class ImageUtility:
     """
         Contains methods for determining a mimetype
         and converting an image to base64
@@ -55,7 +55,7 @@ class ImageUtility():
             return
         print(" ! Unable to delete %s, was it already deleted?" % (self.image_path))
 
-class HTMLUtility():
+class HTMLUtility:
     """
         Contains methods for making changes to a provided html file
     """
@@ -104,28 +104,40 @@ class HTMLUtility():
             contains the base64 representation of
             the image
         """
+        image_paths = []
+
         # Determine the path where the files are located
         base_path = os.path.split(self.html_path.rstrip(os.path.sep))[0]
 
         soup = BeautifulSoup(self.read_html(), 'html.parser')
 
         print(" > Parsing %s for <img> tags" % (self.html_path))
+        # Embed all the images first
         for dest_image in soup.find_all('img'):
             # Determine where the image is, relative to the html file
-            img_path = os.path.join(base_path, dest_image.attrs['src'])
-            img_util = ImageUtility(img_path)
+            image_path = os.path.join(base_path, dest_image.attrs['src'])
+
+            # Store the path to the image for future deletion
+            if image_path not in image_paths:
+                image_paths.append(image_path)
+
+            # Create an instance of the conversion object
+            image_util = ImageUtility(image_path)
 
             # Get the mimetype and base64 representation
-            img_mime = img_util.get_mimetype()
-            img_b64 = img_util.convert_to_base64()
+            image_mime = image_util.get_mimetype()
+            image_b64 = image_util.convert_to_base64()
 
             # Change the image `src` link
-            print(" > Embedding %s into %s" % (img_path, self.html_path))
-            img_src = "data:%s;base64,%s" % (img_mime, img_b64)
-            dest_image.attrs['src'] = img_src
+            print(" > Embedding %s into %s" % (image_path, self.html_path))
+            image_src = "data:%s;base64,%s" % (image_mime, image_b64)
+            dest_image.attrs['src'] = image_src
 
+        # Delete the images now that they have all been embedded
+        for image_path in image_paths:
+            image_util = ImageUtility(image_path)
             # Remove the image as it is no longer needed
-            img_util.delete_image()
+            image_util.delete_image()
 
         self.write_html(str(soup))
 

--- a/bin/inline-image
+++ b/bin/inline-image
@@ -43,9 +43,17 @@ class ImageUtility():
         with open(self.image_path, 'rb') as the_image:
             image_contents = base64.b64encode(the_image.read())
         the_image.close()
-        print(" > Deleting %s" % (self.image_path))
-        os.remove(self.image_path)
         return image_contents.decode('utf-8')
+
+    def delete_image(self):
+        """
+            Deletes the image, after it has already been embedded
+        """
+        if os.path.exists(self.image_path):
+            print(" > Deleting %s" % (self.image_path))
+            os.remove(self.image_path)
+            return
+        print(" ! Unable to delete %s, was it already deleted?" % (self.image_path))
 
 class HTMLUtility():
     """
@@ -115,6 +123,9 @@ class HTMLUtility():
             print(" > Embedding %s into %s" % (img_path, self.html_path))
             img_src = "data:%s;base64,%s" % (img_mime, img_b64)
             dest_image.attrs['src'] = img_src
+
+            # Remove the image as it is no longer needed
+            img_util.delete_image()
 
         self.write_html(str(soup))
 

--- a/readme.md
+++ b/readme.md
@@ -10,11 +10,12 @@ The images contained within the files are extracted and stored alongside the htm
 1. Ensure that you have [Docker](https://docs.docker.com/get-started/) setup on your machine
 1. Download the latest [Alpine Linux](https://alpinelinux.org/) release - `sudo docker pull alpine:edge`
 1. Clone this repo - `git clone https://github.com/dtodd-wipeos/alpine-unoconv`
-1. Create a directory called `docs` inside this repository
 1. Fill the `docs` directory with your files. I've tested this with `doc` and `docx` formats, but any that libreoffice can read should work.
-1. Build and run the container `sudo ./build.sh`. Subsequent runs will only require you to do `sudo ./run.sh`
-1. Your HTML and image files will be located alongside the documents
-1. Clear out the `docs` directory and add more files, using `run.sh` as needed
+    * The files **MUST NOT** be protected with a password. They will return garbled data (or even hang the container) otherwise
+5. Build and run the container `sudo ./build.sh`. Subsequent runs will only require you to do `sudo ./run.sh`
+1. The HTML version of the documents will be located in the `docs` directory, alongside your source documents
+    * Any images that were in the documents will be automatically extracted and embedded into the HTML files
+7. Clear out the `docs` directory and add more files, using `run.sh` as needed
 
 ## License - MIT
 

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # Alpine-Unoconv
 
 This docker container gives a way to mass convert office files (such as doc and docx) to HTML.
-The images contained within the files are extracted and stored alongside the html files.
+The images contained within the files are extracted and embedded into the HTML output files.
 
 [unoconv](https://github.com/unoconv/unoconv) is the tool that is used to do the conversion (it uses [libreoffice](https://www.libreoffice.org/) as the backend). This tool is automatically downloaded during the build process, and not included as a part of this repo.
 


### PR DESCRIPTION
This Feature will take the extracted images (if there are any), convert them to base64, and embed them directly into the HTML files

This is to give the HTML file portability in terms of not having to upload extra files/attachments